### PR TITLE
!!CRITICAL!! Fix Object Dragging & ChildObj Saving

### DIFF
--- a/src/whitehole/editor/GalaxyEditorForm.java
+++ b/src/whitehole/editor/GalaxyEditorForm.java
@@ -2109,22 +2109,20 @@ public class GalaxyEditorForm extends javax.swing.JFrame {
         String stageKey = String.format("%d/%s", curScenarioID, curZone);
         if(zonePlacements.containsKey(stageKey)) {
             StageObj szdata = zonePlacements.get(stageKey);
-            
-            float rotY = szdata.rotation.y;
-            
-            float xcos =(float) Math.cos(-((int)szdata.rotation.z * Math.PI) / 180f);
-            float xsin =(float) Math.sin(-((int)szdata.rotation.z * Math.PI) / 180f);
-            float ycos =(float) Math.cos(-((int)rotY * Math.PI) / 180f);
-            float ysin =(float) Math.sin(-((int)rotY * Math.PI) / 180f);
-            float zcos =(float) Math.cos(-((int)szdata.rotation.x * Math.PI) / 180f);
-            float zsin =(float) Math.sin(-((int)szdata.rotation.x * Math.PI) / 180f);
 
-            float x1 =(delta.x * zcos) -(delta.y * zsin);
-            float y1 =(delta.x * zsin) +(delta.y * zcos);
-            float x2 =(x1 * ycos) +(delta.z * ysin);
-            float z2 = -(x1 * ysin) +(delta.z * ycos);
-            float y3 =(y1 * xcos) -(z2 * xsin);
-            float z3 =(y1 * xsin) +(z2 * xcos);
+            float xcos = (float)Math.cos(-(szdata.rotation.x * Math.PI) / 180f);
+            float xsin = (float)Math.sin(-(szdata.rotation.x * Math.PI) / 180f);
+            float ycos = (float)Math.cos(-(szdata.rotation.y * Math.PI) / 180f);
+            float ysin = (float)Math.sin(-(szdata.rotation.y * Math.PI) / 180f);
+            float zcos = (float)Math.cos(-(szdata.rotation.z * Math.PI) / 180f);
+            float zsin = (float)Math.sin(-(szdata.rotation.z * Math.PI) / 180f);
+
+            float x1 = (delta.x * zcos) - (delta.y * zsin);
+            float y1 = (delta.x * zsin) + (delta.y * zcos);
+            float x2 = (x1 * ycos) + (delta.z * ysin);
+            float z2 = -(x1 * ysin) + (delta.z * ycos);
+            float y3 = (y1 * xcos) - (z2 * xsin);
+            float z3 = (y1 * xsin) + (z2 * xcos);
 
             delta.x = x2;
             delta.y = y3;

--- a/src/whitehole/smg/StageHelper.java
+++ b/src/whitehole/smg/StageHelper.java
@@ -465,13 +465,14 @@ public class StageHelper {
         bcsv.addField("CastId", 0, -1, 0, -1);
         bcsv.addField("ViewGroupId", 0, -1, 0, -1);
         bcsv.addField("MessageId", 0, -1, 0, -1);
-        bcsv.addField("ParentID", 4, -1, 0, (short)-1);
-        bcsv.addField("ShapeModelNo", 4, -1, 0, (short)-1);
-        bcsv.addField("CommonPath_ID", 4, -1, 0, (short)-1);
-        bcsv.addField("ClippingGroupId", 4, -1, 0, (short)-1);
-        bcsv.addField("GroupId", 4, -1, 0, (short)-1);
-        bcsv.addField("DemoGroupId", 4, -1, 0, (short)-1);
-        bcsv.addField("MapParts_ID", 4, -1, 0, (short)-1);
+        
+        bcsv.addField("ParentID", 4, 0xFFFF, 0, (short)-1);
+        bcsv.addField("ShapeModelNo", 4, 0xFFFF, 0, (short)-1);
+        bcsv.addField("CommonPath_ID", 4, 0xFFFF, 0, (short)-1);
+        bcsv.addField("ClippingGroupId", 4, 0xFFFF, 0, (short)-1);
+        bcsv.addField("GroupId", 4, 0xFFFF, 0, (short)-1);
+        bcsv.addField("DemoGroupId", 4, 0xFFFF, 0, (short)-1);
+        bcsv.addField("MapParts_ID", 4, 0xFFFF, 0, (short)-1);
     }
     
     private static void populateJMapFieldsSoundInfo(Bcsv bcsv) {


### PR DESCRIPTION
This fix should be merged and deployed immediately.

- Fixed object dragging in rotated zones.
- Fixed ChildObj's BCSV Hashes from being saved incorrectly as 0xFFFFFFFF (-1). It now saves correctly as 0xFFFF