### PR TITLE
Add option to show galaxy file names

### DIFF
--- a/src/whitehole/MainFrame.java
+++ b/src/whitehole/MainFrame.java
@@ -65,7 +65,7 @@ public final class MainFrame extends javax.swing.JFrame {
         settingsDialog = new SettingsForm(this);
     }
     
-    private void openGameDir(String gameDir) {
+    public void openGameDir(String gameDir) {
         btnOpenGalaxy.setEnabled(false);
         btnBcsvEditor.setEnabled(false);
         

--- a/src/whitehole/Settings.java
+++ b/src/whitehole/Settings.java
@@ -28,7 +28,7 @@ public final class Settings {
     public static String getLastGameDir() { return PREFERENCES.get("whitehole_lastGameDir", null); }
     public static boolean getSJISNotSupported() { return PREFERENCES.getBoolean("whitehole_sjisNotSupported", false); }
     public static boolean getUseDarkMode() { return PREFERENCES.getBoolean("whitehole_useDarkMode", true); }
-    public static boolean getUseGalaxyFileNames() { return PREFERENCES.getBoolean("whitehole_useGalaxyFileNames", true);}
+    public static boolean getUseGalaxyFileNames() { return PREFERENCES.getBoolean("whitehole_useGalaxyFileNames", false);}
     
     public static void setLastGameDir(String val) { PREFERENCES.put("whitehole_lastGameDir", val); }
     public static void setSJISNotSupported(boolean val) { PREFERENCES.putBoolean("whitehole_sjisNotSupported", val); }

--- a/src/whitehole/Settings.java
+++ b/src/whitehole/Settings.java
@@ -28,10 +28,12 @@ public final class Settings {
     public static String getLastGameDir() { return PREFERENCES.get("whitehole_lastGameDir", null); }
     public static boolean getSJISNotSupported() { return PREFERENCES.getBoolean("whitehole_sjisNotSupported", false); }
     public static boolean getUseDarkMode() { return PREFERENCES.getBoolean("whitehole_useDarkMode", true); }
+    public static boolean getUseGalaxyFileNames() { return PREFERENCES.getBoolean("whitehole_useGalaxyFileNames", true);}
     
     public static void setLastGameDir(String val) { PREFERENCES.put("whitehole_lastGameDir", val); }
     public static void setSJISNotSupported(boolean val) { PREFERENCES.putBoolean("whitehole_sjisNotSupported", val); }
     public static void setUseDarkMode(boolean val) { PREFERENCES.putBoolean("whitehole_useDarkMode", val); }
+    public static void setUseGalaxyFileNames(boolean val) { PREFERENCES.putBoolean("whitehole_useGalaxyFileNames", val); }
     
     // Rendering
     public static boolean getShowAxis() { return PREFERENCES.getBoolean("whitehole_showAxis", true); }

--- a/src/whitehole/SettingsForm.form
+++ b/src/whitehole/SettingsForm.form
@@ -230,6 +230,23 @@
             </Constraint>
           </Constraints>
         </Component>
+        <Component class="javax.swing.JCheckBox" name="chkUseGalaxyFileNames">
+          <Properties>
+            <Property name="selected" type="boolean" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="Settings.getUseGalaxyFileNames()" type="code"/>
+            </Property>
+            <Property name="text" type="java.lang.String" value="Use Galaxy File Names"/>
+          </Properties>
+          <Events>
+            <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="chkUseGalaxyFileNamesItemStateChanged"/>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chkUseGalaxyFileNamesActionPerformed"/>
+          </Events>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="-1" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
       </SubComponents>
     </Container>
   </SubComponents>

--- a/src/whitehole/SettingsForm.java
+++ b/src/whitehole/SettingsForm.java
@@ -57,6 +57,7 @@ public class SettingsForm extends javax.swing.JDialog {
         btnPosition = new KeybindButton();
         btnRotation = new KeybindButton();
         btnScale = new KeybindButton();
+        chkUseGalaxyFileNames = new javax.swing.JCheckBox();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setTitle(String.format("%s -- Settings", Whitehole.NAME));
@@ -196,6 +197,24 @@ public class SettingsForm extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
         pnlSettings.add(btnScale, gridBagConstraints);
 
+        chkUseGalaxyFileNames.setSelected(Settings.getUseGalaxyFileNames());
+        chkUseGalaxyFileNames.setText("Use Galaxy File Names");
+        chkUseGalaxyFileNames.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                chkUseGalaxyFileNamesItemStateChanged(evt);
+            }
+        });
+        chkUseGalaxyFileNames.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                chkUseGalaxyFileNamesActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        pnlSettings.add(chkUseGalaxyFileNames, gridBagConstraints);
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
@@ -243,6 +262,15 @@ public class SettingsForm extends javax.swing.JDialog {
         Settings.setUseDarkMode(evt.getStateChange() == ItemEvent.SELECTED);
         Whitehole.requestUpdateLAF();
     }//GEN-LAST:event_chkUseDarkModeItemStateChanged
+
+    private void chkUseGalaxyFileNamesItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_chkUseGalaxyFileNamesItemStateChanged
+        Settings.setUseGalaxyFileNames(evt.getStateChange() == ItemEvent.SELECTED);
+        Whitehole.updateGalaxyList();
+    }//GEN-LAST:event_chkUseGalaxyFileNamesItemStateChanged
+
+    private void chkUseGalaxyFileNamesActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkUseGalaxyFileNamesActionPerformed
+        
+    }//GEN-LAST:event_chkUseGalaxyFileNamesActionPerformed
     
     private static class KeybindButton extends JButton {
         boolean binding = false;
@@ -293,6 +321,7 @@ public class SettingsForm extends javax.swing.JDialog {
     private javax.swing.JCheckBox chkDebugFakeColor;
     private javax.swing.JCheckBox chkDebugFastDrag;
     private javax.swing.JCheckBox chkUseDarkMode;
+    private javax.swing.JCheckBox chkUseGalaxyFileNames;
     private javax.swing.JCheckBox chkUseReverseRot;
     private javax.swing.JCheckBox chkUseWASD;
     private javax.swing.JLabel lblAppearance;

--- a/src/whitehole/Whitehole.java
+++ b/src/whitehole/Whitehole.java
@@ -74,6 +74,10 @@ public class Whitehole {
         MAIN_FRAME.setVisible(true);
     }
     
+    public static void updateGalaxyList() {
+        MAIN_FRAME.openGameDir(Settings.getLastGameDir());
+    }
+    
     public static void requestUpdateLAF() {
         LookAndFeel next = null;
         

--- a/src/whitehole/db/GalaxyNames.java
+++ b/src/whitehole/db/GalaxyNames.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import whitehole.Settings;
 import whitehole.io.ExternalFilesystem;
 
 public final class GalaxyNames {
@@ -66,6 +67,6 @@ public final class GalaxyNames {
     
     public static String getSimplifiedStageName(String stage) {
         JSONObject dbSrc = projectStageNames != null ? projectStageNames : originalStageNames;
-        return dbSrc.optString(stage, String.format("\"%s\"", stage));
+        return Settings.getUseGalaxyFileNames() ? dbSrc.optString(stage, String.format("\"%s\"", stage)) : stage;
     }
 }

--- a/src/whitehole/db/GalaxyNames.java
+++ b/src/whitehole/db/GalaxyNames.java
@@ -67,6 +67,6 @@ public final class GalaxyNames {
     
     public static String getSimplifiedStageName(String stage) {
         JSONObject dbSrc = projectStageNames != null ? projectStageNames : originalStageNames;
-        return Settings.getUseGalaxyFileNames() ? dbSrc.optString(stage, String.format("\"%s\"", stage)) : stage;
+        return !Settings.getUseGalaxyFileNames() ? dbSrc.optString(stage, String.format("\"%s\"", stage)) : stage;
     }
 }


### PR DESCRIPTION
Some people prefer filenames for galaxies, so I added a setting to show them instead of ingame names.

For people who have no idea what I'm talking about: Flip Swap's file name is RedBlueExGalaxy. This setting shows that instead of the actual galaxy name.
![image](https://github.com/SunakazeKun/Whitehole-Despaghettification/assets/100500023/e6baeecc-24d7-47c7-8bdd-40e215c27bde)
![image](https://github.com/SunakazeKun/Whitehole-Despaghettification/assets/100500023/815da8db-1fcf-4008-831a-44410f4e3b66)